### PR TITLE
Handle Office document attachments without LibreOffice

### DIFF
--- a/backend/lambda_function.py
+++ b/backend/lambda_function.py
@@ -81,42 +81,96 @@ def _get_body_bytes(event: Dict[str, Any]) -> bytes:
     return body or b""
 
 def convert_office_to_pdf(data: bytes, ext: str) -> bytes | None:
-    """Convert .doc/.docx bytes to PDF using LibreOffice if available."""
+    """Convert .doc/.docx bytes to PDF bytes.
+
+    Uses LibreOffice if available. If that fails (e.g. binary missing), fall back
+    to a pure-Python approach for ``.docx`` (``mammoth``) or a best-effort text
+    extraction for ``.doc`` via the ``antiword`` command. The resulting HTML/text
+    is rendered to PDF using :func:`html_to_pdf`.
+    """
+    src_path = None
+    out_dir = None
+    pdf_path = None
     try:
         with tempfile.NamedTemporaryFile(suffix=ext, delete=False) as src:
             src.write(data)
             src.flush()
+            src_path = src.name
         out_dir = tempfile.mkdtemp()
         cmd = [
             'libreoffice',
             '--headless',
             '--convert-to',
             'pdf',
-            src.name,
+            src_path,
             '--outdir',
             out_dir,
         ]
         subprocess.run(cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        pdf_path = os.path.join(out_dir, os.path.splitext(os.path.basename(src.name))[0] + '.pdf')
+        pdf_path = os.path.join(out_dir, os.path.splitext(os.path.basename(src_path))[0] + '.pdf')
         with open(pdf_path, 'rb') as f:
             return f.read()
     except Exception as e:
         logger.warning(f"DOC/DOCX conversion failed: {e}")
+        try:
+            html_content = None
+            lower_ext = ext.lower()
+            if lower_ext == '.docx':
+                try:
+                    import mammoth  # type: ignore
+                    html_content = mammoth.convert_to_html(io.BytesIO(data)).value
+                except Exception as me:
+                    logger.warning(f"mammoth conversion failed: {me}")
+            elif lower_ext == '.doc':
+                try:
+                    with tempfile.NamedTemporaryFile(suffix=ext, delete=False) as tmp:
+                        tmp.write(data)
+                        tmp.flush()
+                        tmp_path = tmp.name
+                    try:
+                        result = subprocess.run(
+                            ['antiword', tmp_path],
+                            check=True,
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE,
+                        )
+                        text = result.stdout.decode('utf-8', 'replace')
+                        html_content = f"<pre>{html.escape(text)}</pre>"
+                    finally:
+                        try:
+                            os.remove(tmp_path)
+                        except Exception:
+                            pass
+                except Exception as te:
+                    logger.warning(f"antiword conversion failed: {te}")
+
+            if html_content:
+                tmp_pdf_fd, tmp_pdf_path = tempfile.mkstemp(suffix='.pdf')
+                os.close(tmp_pdf_fd)
+                try:
+                    html_to_pdf(html_content, tmp_pdf_path)
+                    with open(tmp_pdf_path, 'rb') as f:
+                        return f.read()
+                finally:
+                    try:
+                        os.remove(tmp_pdf_path)
+                    except Exception:
+                        pass
+        except Exception as fe:
+            logger.warning(f"Fallback DOC/DOCX conversion failed: {fe}")
         return None
     finally:
-        try:
-            os.remove(src.name)
-        except Exception:
-            pass
-        try:
-            if 'pdf_path' in locals() and os.path.exists(pdf_path):
-                os.remove(pdf_path)
-        except Exception:
-            pass
-        try:
-            shutil.rmtree(out_dir)
-        except Exception:
-            pass
+        for p in (src_path, pdf_path):
+            if p and os.path.exists(p):
+                try:
+                    os.remove(p)
+                except Exception:
+                    pass
+        if out_dir:
+            try:
+                shutil.rmtree(out_dir)
+            except Exception:
+                pass
 
 def eml_bytes_to_pdf_bytes(eml_bytes: bytes) -> bytes | None:
     """Convert EML bytes to PDF bytes using convert_eml_to_pdf helper."""
@@ -363,6 +417,11 @@ def convert_msg_bytes_to_eml_bytes(msg_bytes: bytes) -> bytes:
             if hasattr(m, 'as_email'):
                 try:
                     em = m.as_email()
+                except Exception:
+                    em = None
+            if em is None and hasattr(m, 'asEmailMessage'):
+                try:
+                    em = m.asEmailMessage()
                 except Exception:
                     em = None
             if em is None:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,6 +12,7 @@ psutil==5.9.6  # For memory monitoring and process management
 extract-msg
 olefile
 tzlocal
+mammoth==1.6.0
 # For AWS Lambda PDF generation - provided by the layer at runtime
 # pyppeteer-core>=1.0.0
 # chrome-aws-lambda>=8.0.2


### PR DESCRIPTION
## Summary
- convert .doc and .docx attachments to PDF using mammoth or antiword when LibreOffice isn't available
- support new extract-msg API by checking for `asEmailMessage`
- add mammoth dependency for Python fallback conversion

## Testing
- `python - <<'PY'
from backend.app import EMLToPDFConverter
conv = EMLToPDFConverter()
msg_path='test_msg_files/_External_ Starlight Solar comment letter.msg'
with open(msg_path,'rb') as f:
    msg_bytes=f.read()
eml_bytes=conv.msg_bytes_to_eml_bytes(msg_bytes)
print('eml_bytes', len(eml_bytes) if eml_bytes else None)
if eml_bytes:
    pdf_bytes=conv.eml_bytes_to_pdf_bytes(eml_bytes)
    print('pdf_bytes', len(pdf_bytes) if pdf_bytes else None)
    if pdf_bytes:
        open('converted_files/test_output.pdf','wb').write(pdf_bytes)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68c2621642f48322a6fd6ec3fcf6724b