### PR TITLE
Refactor lambda into modular classes

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,51 @@
+# Backend Lambda Overview
+
+This backend exposes a message conversion API used by the project.  The code has been
+refactored to introduce a few lightweight classes that make the behavior easier to
+follow and maintain.
+
+## Key Components
+
+### `EmailConverter`
+Located in `converter.py`, this class wraps the heavy lifting required to turn
+Outlook `.msg` files into standard EML documents while extracting any embedded
+attachments.  The Lambda module exposes thin wrapper functions so existing code
+can continue to call `convert_msg_bytes_to_eml_bytes` or
+`convert_msg_bytes_to_eml_bytes_with_attachments` without modification.
+
+### `LambdaRouter`
+Defined in `router.py`, the router centralizes request dispatching and CORS
+handling.  It maps incoming API Gateway paths to the appropriate handler
+functions while verifying that Playwright is available for PDF rendering.
+
+### `DocumentConverter`
+Found in `document_converter.py`, this class groups together the heavy
+document and email conversion helpers.  It powers functions like
+`convert_docx_to_html_with_images` and `convert_office_to_pdf` while delegating
+HTML-to-PDF rendering back to the Lambda module.
+
+### `RequestParser`
+Found in `request_parser.py`, this helper normalizes headers and body
+extraction from API Gateway events. Handlers construct an instance to
+access lowercase headers, raw body bytes, or parsed JSON without duplicating
+boilerplate logic.
+
+### `MultipartParser`
+Located in `multipart_parser.py`, this class decodes `multipart/form-data`
+payloads and gracefully falls back to single-file uploads when boundaries
+are missing. The Lambda handlers use it to process uploaded `.eml` files.
+
+### `lambda_function.py`
+The main entry point now simply configures logging, initializes the converter
+and router, wires up the parsers, and delegates each invocation to
+`LambdaRouter.handle`.  Browser processes are cleaned up after every request.
+
+## Extending
+
+1. Implement new handler functions in `lambda_function.py`.
+2. Register them in the `HANDLERS` mapping near the bottom of the file.
+3. The router will automatically add the correct CORS headers and invoke your
+   handler.
+
+This structure keeps the Lambda entry point compact while isolating complex
+conversion logic into well-scoped classes.

--- a/backend/converter.py
+++ b/backend/converter.py
@@ -1,0 +1,546 @@
+import os
+import tempfile
+import io
+import logging
+from email.message import EmailMessage
+from email.generator import BytesGenerator
+from email.policy import default
+from email.utils import format_datetime
+from datetime import datetime
+from typing import List, Dict, Any, Tuple
+
+import extract_msg
+
+class EmailConverter:
+    """Utilities for working with Outlook ``.msg`` files and EML conversion."""
+
+    def __init__(self, logger: logging.Logger | None = None) -> None:
+        self.logger = logger or logging.getLogger(__name__)
+
+    def extract_msg_attachments_with_embedded(self, msg_path: str, output_dir: str) -> list:
+        """Extract attachments from a ``.msg`` file, handling embedded messages."""
+        import tempfile
+        try:
+            if self.logger:
+                self.logger.info(f"Extracting attachments from: {msg_path}")
+
+            attachments = []
+
+            with extract_msg.Message(msg_path) as msg:
+                if self.logger:
+                    self.logger.info(f"DEBUGGING: Total attachments found: {len(msg.attachments)}")
+                    for i, att in enumerate(msg.attachments):
+                        att_type = getattr(att, 'type', 'unknown')
+                        att_name = getattr(att, 'longFilename', None) or getattr(att, 'shortFilename', 'unknown')
+                        self.logger.info(
+                            f"DEBUGGING: Attachment {i+1}: type='{att_type}', name='{att_name}'"
+                        )
+
+                for attachment in msg.attachments:
+                    try:
+                        if hasattr(attachment, 'type') and attachment.type == "data":
+                            att_data = attachment.data
+                            att_name = getattr(attachment, 'longFilename', None) or getattr(
+                                attachment, 'shortFilename', 'unknown'
+                            )
+                            if att_name.lower().endswith('.pdf'):
+                                content_type = 'application/pdf'
+                            elif att_name.lower().endswith(('.jpg', '.jpeg')):
+                                content_type = 'image/jpeg'
+                            elif att_name.lower().endswith('.png'):
+                                content_type = 'image/png'
+                            else:
+                                content_type = 'application/octet-stream'
+
+                            attachments.append(
+                                {
+                                    'filename': att_name,
+                                    'content_type': content_type,
+                                    'data': att_data,
+                                }
+                            )
+
+                            if self.logger:
+                                self.logger.info(
+                                    f"Successfully extracted regular attachment: {att_name} ({len(att_data)} bytes)"
+                                )
+
+                        elif hasattr(attachment, 'type') and attachment.type == "msg":
+                            if self.logger:
+                                self.logger.info("DEBUGGING: Found embedded .msg attachment")
+                            try:
+                                embedded_msg = attachment.data
+                                att_name = getattr(attachment, 'longFilename', None) or getattr(
+                                    attachment, 'shortFilename', 'embedded_message.msg'
+                                )
+
+                                if self.logger:
+                                    self.logger.info(f"DEBUGGING: Processing embedded .msg: {att_name}")
+
+                                try:
+                                    with tempfile.NamedTemporaryFile(suffix='.msg', delete=False) as tmp_file:
+                                        embedded_msg.save(tmp_file.name, raw=True)
+                                        tmp_file.flush()
+                                        with open(tmp_file.name, 'rb') as f:
+                                            msg_bytes = f.read()
+                                        eml_bytes = self.convert_msg_bytes_to_eml_bytes(msg_bytes)
+                                        final_name = os.path.splitext(att_name)[0] + '.eml'
+                                        attachments.append(
+                                            {
+                                                'filename': final_name,
+                                                'content_type': 'message/rfc822',
+                                                'data': eml_bytes,
+                                            }
+                                        )
+                                        if self.logger:
+                                            self.logger.info(
+                                                f"DEBUGGING: Successfully converted embedded .msg to EML: {final_name} ({len(eml_bytes)} bytes)"
+                                            )
+                                        os.unlink(tmp_file.name)
+                                        continue
+                                except Exception as direct_e:
+                                    if self.logger:
+                                        self.logger.warning(
+                                            f"DEBUGGING: Direct .msg conversion failed: {direct_e}, trying save method"
+                                        )
+
+                                with tempfile.TemporaryDirectory() as temp_dir:
+                                    save_result = embedded_msg.save(customPath=temp_dir, useFileName=True)
+                                    if self.logger:
+                                        self.logger.info(f"Items created by save(): {save_result}")
+                                    for root, dirs, files in os.walk(temp_dir):
+                                        if self.logger:
+                                            self.logger.info(f"Files inside extracted dir: {files}")
+                                        for filename in files:
+                                            try:
+                                                lower = filename.lower()
+                                                file_path = os.path.join(root, filename)
+                                                if lower.endswith('.eml'):
+                                                    with open(file_path, 'rb') as f:
+                                                        eml_bytes = f.read()
+                                                    final_name = (
+                                                        att_name
+                                                        if att_name.lower().endswith('.eml')
+                                                        else os.path.splitext(att_name)[0] + '.eml'
+                                                    )
+                                                    attachments.append(
+                                                        {
+                                                            'filename': final_name,
+                                                            'content_type': 'message/rfc822',
+                                                            'data': eml_bytes,
+                                                        }
+                                                    )
+                                                    if self.logger:
+                                                        self.logger.info(
+                                                            f"Successfully extracted embedded EML: {final_name} ({len(eml_bytes)} bytes)"
+                                                        )
+                                                    raise StopIteration
+                                                if lower.endswith('.msg'):
+                                                    with open(file_path, 'rb') as f:
+                                                        msg_bytes = f.read()
+                                                    try:
+                                                        eml_bytes = self.convert_msg_bytes_to_eml_bytes(msg_bytes)
+                                                        final_name = os.path.splitext(att_name)[0] + '.eml'
+                                                        attachments.append(
+                                                            {
+                                                                'filename': final_name,
+                                                                'content_type': 'message/rfc822',
+                                                                'data': eml_bytes,
+                                                            }
+                                                        )
+                                                        if self.logger:
+                                                            self.logger.info(
+                                                                f"Converted embedded MSG to EML: {final_name} ({len(eml_bytes)} bytes)"
+                                                            )
+                                                        raise StopIteration
+                                                    except Exception as conv_e:
+                                                        if self.logger:
+                                                            self.logger.warning(
+                                                                f"Failed converting embedded .msg to .eml: {conv_e}"
+                                                            )
+                                            except StopIteration:
+                                                files = []
+                                                break
+                                            except Exception as read_any:
+                                                if self.logger:
+                                                    self.logger.warning(
+                                                        f"Error examining extracted file '{filename}': {read_any}"
+                                                    )
+                                        for filename in files:
+                                            if filename in ['message.txt', 'message.html', 'body.txt', 'body.html']:
+                                                file_path = os.path.join(root, filename)
+                                                try:
+                                                    with open(
+                                                        file_path, 'r', encoding='utf-8', errors='replace'
+                                                    ) as f:
+                                                        text_content = f.read()
+                                                    if text_content.strip():
+                                                        text_filename = f"{att_name}.txt"
+                                                        attachments.append(
+                                                            {
+                                                                'filename': text_filename,
+                                                                'content_type': 'text/plain',
+                                                                'data': text_content.encode('utf-8'),
+                                                            }
+                                                        )
+                                                        if self.logger:
+                                                            self.logger.info(
+                                                                f"Successfully extracted embedded attachment: {text_filename} ({len(text_content)} bytes, type: text/plain)"
+                                                            )
+                                                        break
+                                                except Exception as read_e:
+                                                    if self.logger:
+                                                        self.logger.warning(
+                                                            f"Could not read {filename}: {read_e}"
+                                                        )
+                            except Exception as embedded_e:
+                                if self.logger:
+                                    self.logger.warning(
+                                        f"Failed to extract embedded .msg: {embedded_e}"
+                                    )
+                        else:
+                            if self.logger:
+                                self.logger.info(
+                                    "DEBUGGING: Found attachment with unknown/missing type, investigating..."
+                                )
+                            try:
+                                att_name = getattr(
+                                    attachment, 'longFilename', None
+                                ) or getattr(attachment, 'shortFilename', None)
+                                if self.logger:
+                                    self.logger.info(
+                                        f"DEBUGGING: Investigating unknown attachment - name: '{att_name}', has_data: {hasattr(attachment, 'data')}"
+                                    )
+                                att_name_safe = att_name or 'embedded_message'
+                                if hasattr(attachment, 'data') and attachment.data:
+                                    if (
+                                        att_name_safe.lower().endswith('.msg')
+                                        or hasattr(attachment.data, 'save')
+                                        or hasattr(attachment.data, 'subject')
+                                        or str(getattr(attachment, 'type', '')) == '1'
+                                    ):
+                                        if self.logger:
+                                            self.logger.info(
+                                                f"DEBUGGING: Treating unknown attachment as embedded message: {att_name_safe}"
+                                            )
+                                        try:
+                                            embedded_data = attachment.data
+                                            if hasattr(embedded_data, 'as_email') or hasattr(
+                                                embedded_data, 'asEmailMessage'
+                                            ):
+                                                try:
+                                                    if self.logger:
+                                                        self.logger.info(
+                                                            "DEBUGGING: Attempting direct conversion of embedded Message object"
+                                                        )
+                                                    if hasattr(embedded_data, 'as_email'):
+                                                        email_obj = embedded_data.as_email()
+                                                    elif hasattr(embedded_data, 'asEmailMessage'):
+                                                        email_obj = embedded_data.asEmailMessage()
+                                                    else:
+                                                        raise Exception("No conversion method available")
+                                                    buf = io.BytesIO()
+                                                    BytesGenerator(buf, policy=default).flatten(email_obj)
+                                                    eml_bytes = buf.getvalue()
+                                                    final_name = 'Fwd_JCSD_construction_water_sales_availablity.eml'
+                                                    attachments.append(
+                                                        {
+                                                            'filename': final_name,
+                                                            'content_type': 'message/rfc822',
+                                                            'data': eml_bytes,
+                                                        }
+                                                    )
+                                                    if self.logger:
+                                                        self.logger.info(
+                                                            f"DEBUGGING: Successfully converted embedded message directly to EML: {final_name} ({len(eml_bytes)} bytes)"
+                                                        )
+                                                    continue
+                                                except Exception as direct_e:
+                                                    if self.logger:
+                                                        self.logger.warning(
+                                                            f"DEBUGGING: Direct conversion failed: {direct_e}, trying save method"
+                                                        )
+                                            if hasattr(embedded_data, 'save'):
+                                                try:
+                                                    with tempfile.TemporaryDirectory() as temp_extract_dir:
+                                                        if self.logger:
+                                                            self.logger.info(
+                                                                f"DEBUGGING: Trying save method in temp dir: {temp_extract_dir}"
+                                                            )
+                                                        save_result = embedded_data.save(
+                                                            customPath=temp_extract_dir, useFileName=True
+                                                        )
+                                                        if self.logger:
+                                                            self.logger.info(
+                                                                f"DEBUGGING: Save result: {save_result}"
+                                                            )
+                                                        for root, dirs, files in os.walk(temp_extract_dir):
+                                                            if self.logger:
+                                                                self.logger.info(
+                                                                    f"DEBUGGING: Files in {root}: {files}"
+                                                                )
+                                                            for filename in files:
+                                                                if filename.lower().endswith(('.eml', '.msg')):
+                                                                    file_path = os.path.join(root, filename)
+                                                                    with open(file_path, 'rb') as f:
+                                                                        saved_bytes = f.read()
+                                                                    if filename.lower().endswith('.msg'):
+                                                                        eml_bytes = self.convert_msg_bytes_to_eml_bytes(
+                                                                            saved_bytes
+                                                                        )
+                                                                    else:
+                                                                        eml_bytes = saved_bytes
+                                                                    final_name = 'Fwd_JCSD_construction_water_sales_availablity.eml'
+                                                                    attachments.append(
+                                                                        {
+                                                                            'filename': final_name,
+                                                                            'content_type': 'message/rfc822',
+                                                                            'data': eml_bytes,
+                                                                        }
+                                                                    )
+                                                                    if self.logger:
+                                                                        self.logger.info(
+                                                                            f"DEBUGGING: Successfully extracted embedded message via save: {final_name} ({len(eml_bytes)} bytes)"
+                                                                        )
+                                                                    break
+                                                            if attachments:
+                                                                break
+                                                except Exception as save_e:
+                                                    if self.logger:
+                                                        self.logger.warning(
+                                                            f"DEBUGGING: Save method also failed: {save_e}"
+                                                        )
+                                        except Exception as unknown_e:
+                                            if self.logger:
+                                                self.logger.warning(
+                                                    f"DEBUGGING: Failed to process unknown attachment: {unknown_e}"
+                                                )
+                            except Exception as detect_e:
+                                if self.logger:
+                                    self.logger.warning(
+                                        f"DEBUGGING: Error detecting attachment type: {detect_e}"
+                                    )
+                    except Exception as att_e:
+                        if self.logger:
+                            self.logger.warning(f"Failed to process attachment: {att_e}")
+            return attachments
+        except Exception as e:
+            if self.logger:
+                self.logger.error(f"Error extracting .msg attachments: {e}")
+            return []
+
+    def convert_msg_bytes_to_eml_bytes(self, msg_bytes: bytes) -> bytes:
+        """Convert Outlook .msg bytes into RFC 822 EML bytes."""
+        try:
+            self.logger.info(
+                f"DEBUGGING: convert_msg_bytes_to_eml_bytes starting with {len(msg_bytes)} bytes"
+            )
+            with tempfile.NamedTemporaryFile(suffix='.msg', delete=False) as tmpf:
+                tmp_path = tmpf.name
+                tmpf.write(msg_bytes)
+            try:
+                m = extract_msg.Message(tmp_path)
+                self.logger.info("DEBUGGING: extract_msg.Message created successfully")
+                try:
+                    subj = getattr(m, 'subject', None) or ''
+                    sender = getattr(m, 'sender', None) or getattr(
+                        m, 'sender_email', None
+                    ) or ''
+                    self.logger.info(
+                        f"DEBUGGING: Message subject: '{subj}', sender: '{sender}'"
+                    )
+                except Exception as e:
+                    self.logger.warning(
+                        f"DEBUGGING: Error getting basic properties: {e}"
+                    )
+                date_hdr = None
+                try:
+                    date_val = getattr(m, 'date', None)
+                    if isinstance(date_val, datetime):
+                        date_hdr = format_datetime(date_val)
+                    elif date_val:
+                        date_hdr = str(date_val)
+                except Exception:
+                    date_hdr = None
+                em = None
+                if hasattr(m, 'as_email'):
+                    try:
+                        self.logger.info("DEBUGGING: Trying m.as_email() method")
+                        em = m.as_email()
+                        self.logger.info("DEBUGGING: m.as_email() succeeded")
+                    except Exception as e:
+                        self.logger.warning(
+                            f"DEBUGGING: m.as_email() failed: {e}"
+                        )
+                        em = None
+                if em is None and hasattr(m, 'asEmailMessage'):
+                    try:
+                        self.logger.info(
+                            "DEBUGGING: Trying m.asEmailMessage() method"
+                        )
+                        em = m.asEmailMessage()
+                        self.logger.info("DEBUGGING: m.asEmailMessage() succeeded")
+                    except Exception as e:
+                        self.logger.warning(
+                            f"DEBUGGING: m.asEmailMessage() failed: {e}"
+                        )
+                        em = None
+                if em is None:
+                    self.logger.info(
+                        "DEBUGGING: Using manual EmailMessage construction"
+                    )
+                    em = EmailMessage()
+                    subj = getattr(m, 'subject', None) or ''
+                    sender = getattr(m, 'sender', None) or getattr(
+                        m, 'sender_email', None
+                    ) or ''
+                    to_list = getattr(m, 'to', None) or []
+                    cc_list = getattr(m, 'cc', None) or []
+                    bcc_list = getattr(m, 'bcc', None) or []
+                    em['Subject'] = subj
+                    if sender:
+                        em['From'] = sender
+                    if to_list:
+                        em['To'] = ', '.join(
+                            to_list if isinstance(to_list, list) else [str(to_list)]
+                        )
+                    if cc_list:
+                        em['Cc'] = ', '.join(
+                            cc_list if isinstance(cc_list, list) else [str(cc_list)]
+                        )
+                    if bcc_list:
+                        em['Bcc'] = ', '.join(
+                            bcc_list if isinstance(bcc_list, list) else [str(bcc_list)]
+                        )
+                    if date_hdr:
+                        em['Date'] = date_hdr
+                    def _decode_to_str(val):
+                        if val is None:
+                            return ''
+                        if isinstance(val, str):
+                            return val
+                        if isinstance(val, (bytes, bytearray)):
+                            for enc in (
+                                'utf-8',
+                                'cp1252',
+                                'latin1',
+                                'iso-8859-1',
+                            ):
+                                try:
+                                    return val.decode(enc)
+                                except Exception:
+                                    continue
+                            return val.decode('utf-8', errors='replace')
+                        try:
+                            return str(val)
+                        except Exception:
+                            return ''
+                    html_body = _decode_to_str(
+                        getattr(m, 'htmlBody', None) or getattr(m, 'html', None)
+                    )
+                    text_body = _decode_to_str(getattr(m, 'body', None) or '')
+                    self.logger.info(
+                        f"DEBUGGING: Initial body extraction - HTML: {len(html_body)} chars, Text: {len(text_body)} chars"
+                    )
+                    if html_body:
+                        self.logger.info(
+                            f"DEBUGGING: HTML body preview: {html_body[:300]}..."
+                        )
+                    if text_body:
+                        self.logger.info(
+                            f"DEBUGGING: Text body preview: {text_body[:300]}..."
+                        )
+                    try:
+                        rtf_body = _decode_to_str(getattr(m, 'rtfBody', None))
+                        if rtf_body and len(rtf_body) > max(len(html_body), len(text_body)):
+                            self.logger.info(
+                                f"DEBUGGING: RTF body is larger ({len(rtf_body)} chars), using as fallback"
+                            )
+                            text_body = rtf_body
+                        for prop_name in (
+                            'compressedRtf',
+                            'plainTextBody',
+                            'textBody',
+                        ):
+                            try:
+                                alt_content = getattr(m, prop_name, None)
+                                if alt_content:
+                                    decoded = _decode_to_str(alt_content)
+                                    if decoded and len(decoded.strip()) > max(
+                                        len(text_body), len(html_body)
+                                    ):
+                                        self.logger.info(
+                                            f"DEBUGGING: Found better content in {prop_name}: {len(decoded)} chars"
+                                        )
+                                        text_body = decoded
+                                        break
+                            except Exception as alt_e:
+                                self.logger.info(
+                                    f"DEBUGGING: Error accessing {prop_name}: {alt_e}"
+                                )
+                    except Exception:
+                        pass
+                    if html_body:
+                        em.add_alternative(html_body, subtype='html')
+                        if text_body:
+                            em.set_content(text_body)
+                    else:
+                        em.set_content(text_body)
+                buf = io.BytesIO()
+                BytesGenerator(buf, policy=default).flatten(em)
+                eml_bytes = buf.getvalue()
+                return eml_bytes
+            finally:
+                try:
+                    os.unlink(tmp_path)
+                except Exception:
+                    pass
+        except Exception as e:
+            self.logger.error(f".msg to .eml conversion failed: {e}")
+            raise
+
+    def convert_msg_bytes_to_eml_bytes_with_attachments(self, msg_bytes: bytes) -> Tuple[bytes, list]:
+        """
+        Convert Outlook ``.msg`` bytes into RFC 822 EML bytes and extract attachments.
+        Returns tuple of ``(eml_bytes, attachments_list)``.
+        """
+        try:
+            self.logger.info(
+                f"DEBUGGING: Starting .msg conversion with {len(msg_bytes)} bytes"
+            )
+            with tempfile.TemporaryDirectory() as temp_dir:
+                msg_path = os.path.join(temp_dir, 'input.msg')
+                with open(msg_path, 'wb') as f:
+                    f.write(msg_bytes)
+                self.logger.info(
+                    f"DEBUGGING: Written .msg to temp file: {msg_path}"
+                )
+                attachments_dir = os.path.join(temp_dir, 'attachments')
+                extracted_attachments = self.extract_msg_attachments_with_embedded(
+                    msg_path, attachments_dir
+                )
+                self.logger.info(
+                    f"DEBUGGING: Extracted {len(extracted_attachments)} attachments from main .msg"
+                )
+                for i, att in enumerate(extracted_attachments):
+                    self.logger.info(
+                        f"DEBUGGING: Attachment {i+1}: {att.get('filename', 'unknown')} ({att.get('content_type', 'unknown')}, {len(att.get('data', b''))} bytes)"
+                    )
+                self.logger.info("DEBUGGING: Converting main .msg to EML...")
+                eml_bytes = self.convert_msg_bytes_to_eml_bytes(msg_bytes)
+                self.logger.info(
+                    f"DEBUGGING: Main .msg converted to EML: {len(eml_bytes)} bytes"
+                )
+                try:
+                    eml_preview = eml_bytes.decode('utf-8', errors='replace')[:500]
+                    self.logger.info(
+                        f"DEBUGGING: EML content preview: {eml_preview}"
+                    )
+                except Exception as e:
+                    self.logger.warning(
+                        f"DEBUGGING: Could not preview EML content: {e}"
+                    )
+                return eml_bytes, extracted_attachments
+        except Exception as e:
+            self.logger.error(f"Failed to extract .msg with attachments: {e}")
+            return self.convert_msg_bytes_to_eml_bytes(msg_bytes), []

--- a/backend/document_converter.py
+++ b/backend/document_converter.py
@@ -1,0 +1,353 @@
+import os
+import html
+import base64
+import tempfile
+import zipfile
+import subprocess
+import shutil
+
+
+class DocumentConverter:
+    """Handle document and email conversions used by the Lambda handlers."""
+
+    def __init__(self, logger, html_to_pdf_fn=None, eml_to_pdf_fn=None):
+        self.logger = logger
+        self.html_to_pdf = html_to_pdf_fn
+        self.eml_to_pdf = eml_to_pdf_fn
+
+    def convert_doc_with_pypandoc_and_images(self, doc_data: bytes, ext: str) -> str:
+        """Convert .doc/.docx to HTML using pypandoc with enhanced image handling."""
+        try:
+            import pypandoc
+
+            extracted_images = []
+            with tempfile.NamedTemporaryFile(suffix=ext, delete=False) as tmp:
+                tmp.write(doc_data)
+                tmp.flush()
+                tmp_path = tmp.name
+
+            try:
+                if ext.lower() == '.docx':
+                    try:
+                        with zipfile.ZipFile(tmp_path, 'r') as docx_zip:
+                            media_files = [f for f in docx_zip.namelist() if f.startswith('word/media/')]
+                            for media_file in media_files:
+                                try:
+                                    img_data = docx_zip.read(media_file)
+                                    if img_data:
+                                        filename = os.path.basename(media_file)
+                                        if filename.lower().endswith('.png'):
+                                            content_type = 'image/png'
+                                        elif filename.lower().endswith(('.jpg', '.jpeg')):
+                                            content_type = 'image/jpeg'
+                                        elif filename.lower().endswith('.gif'):
+                                            content_type = 'image/gif'
+                                        elif filename.lower().endswith('.bmp'):
+                                            content_type = 'image/bmp'
+                                        else:
+                                            content_type = 'image/png'
+
+                                        b64_data = base64.b64encode(img_data).decode('utf-8')
+                                        data_url = f"data:{content_type};base64,{b64_data}"
+                                        extracted_images.append({
+                                            'filename': filename,
+                                            'data_url': data_url,
+                                            'size': len(img_data),
+                                            'type': content_type
+                                        })
+                                except Exception as e:
+                                    self.logger.warning(f"Failed to extract image {media_file}: {e}")
+                                    continue
+                    except Exception as ze:
+                        self.logger.info(f"Could not extract images from .docx ZIP: {ze}")
+
+                try:
+                    html_content = pypandoc.convert_file(tmp_path, 'html')
+                except OSError:
+                    pypandoc.download_pandoc()
+                    html_content = pypandoc.convert_file(tmp_path, 'html')
+
+                if extracted_images and html_content:
+                    import re
+
+                    image_map = {}
+                    for img in extracted_images:
+                        filename = img['filename']
+                        base_name = os.path.splitext(filename)[0]
+                        possible_refs = [
+                            filename,
+                            f"word/media/{filename}",
+                            f"media/{filename}",
+                            base_name,
+                            f"image{len(image_map) + 1}",
+                        ]
+                        for ref in possible_refs:
+                            image_map[ref] = img['data_url']
+
+                    def replace_img_src(match):
+                        full_tag = match.group(0)
+                        src_match = re.search(r'src=["\']([^"\']+)["\']', full_tag)
+                        if src_match:
+                            original_src = src_match.group(1)
+                            for ref, data_url in image_map.items():
+                                if ref.lower() in original_src.lower() or original_src.lower() in ref.lower():
+                                    return full_tag.replace(original_src, data_url)
+                        return full_tag
+
+                    html_content = re.sub(r'<img[^>]*>', replace_img_src, html_content, flags=re.IGNORECASE)
+
+                    if not re.search(r'<img[^>]*>', html_content, re.IGNORECASE) and extracted_images:
+                        images_html = '<div style="margin-top:20px;"><h4>Document Images:</h4>'
+                        for img in extracted_images:
+                            images_html += f'<img src="{img["data_url"]}" alt="{img["filename"]}" style="max-width:100%;margin:10px 0;" />'
+                        images_html += '</div>'
+                        html_content += images_html
+
+                if html_content:
+                    styled_html = f"""
+                    <style>
+                        img {{
+                            max-width: 100%;
+                            height: auto;
+                            display: block;
+                            margin: 8px 0;
+                        }}
+                        .doc-image {{
+                            max-width: 100%;
+                            height: auto;
+                        }}
+                    </style>
+                    {html_content}
+                    """
+
+                    if extracted_images:
+                        total_size = sum(img['size'] for img in extracted_images)
+                        image_types = list(set(img['type'] for img in extracted_images))
+                        self.logger.info(
+                            f"pypandoc extracted {len(extracted_images)} images (total size: {total_size} bytes, types: {image_types})"
+                        )
+                    else:
+                        self.logger.info("No images found in document")
+
+                    return styled_html
+
+                return html_content or ""
+            finally:
+                try:
+                    os.remove(tmp_path)
+                except Exception:
+                    pass
+
+        except Exception as e:
+            self.logger.error(f"Error in convert_doc_with_pypandoc_and_images: {e}")
+            raise
+
+    def convert_docx_to_html_with_images(self, docx_data: bytes) -> str:
+        """Convert .docx to HTML with embedded images as data URLs."""
+        try:
+            import mammoth
+            import base64
+            import io
+
+            extracted_images = []
+
+            def convert_image(image):
+                try:
+                    image_bytes = image.open().read()
+                    content_type = getattr(image, 'content_type', None)
+                    if not content_type:
+                        if image_bytes.startswith(b'\x89PNG'):
+                            content_type = 'image/png'
+                        elif image_bytes.startswith(b'\xff\xd8\xff'):
+                            content_type = 'image/jpeg'
+                        elif image_bytes.startswith(b'GIF'):
+                            content_type = 'image/gif'
+                        elif image_bytes.startswith(b'RIFF') and b'WEBP' in image_bytes[:20]:
+                            content_type = 'image/webp'
+                        elif image_bytes.startswith(b'BM'):
+                            content_type = 'image/bmp'
+                        else:
+                            content_type = 'image/png'
+
+                    b64_data = base64.b64encode(image_bytes).decode('utf-8')
+                    data_url = f"data:{content_type};base64,{b64_data}"
+
+                    extracted_images.append({
+                        'size': len(image_bytes),
+                        'type': content_type,
+                        'alt_text': getattr(image, 'alt_text', '') or 'Image from Word document'
+                    })
+
+                    return {
+                        "src": data_url,
+                        "alt": getattr(image, 'alt_text', '') or 'Image from Word document'
+                    }
+                except Exception as e:
+                    self.logger.warning(f"Failed to convert image: {e}")
+                    return {}
+
+            convert_options = {
+                'convert_image': mammoth.images.img_element(convert_image),
+                'ignore_empty_paragraphs': False,
+                'preserve_empty_paragraphs': True
+            }
+
+            with io.BytesIO(docx_data) as docx_stream:
+                result = mammoth.convert_to_html(docx_stream, **convert_options)
+                html_content = result.value
+                if result.messages:
+                    for msg in result.messages:
+                        if msg.type == 'warning':
+                            self.logger.warning(f"Mammoth warning: {msg.message}")
+                        elif msg.type == 'error':
+                            self.logger.error(f"Mammoth error: {msg.message}")
+
+            styled_html = f"""
+            <style>
+                img {{
+                    max-width: 100%;
+                    height: auto;
+                    display: block;
+                    margin: 8px 0;
+                }}
+                .word-image {{
+                    max-width: 100%;
+                    height: auto;
+                }}
+            </style>
+            {html_content}
+            """
+
+            if extracted_images:
+                total_size = sum(img['size'] for img in extracted_images)
+                image_types = list(set(img['type'] for img in extracted_images))
+                self.logger.info(
+                    f"Mammoth extracted {len(extracted_images)} images (total size: {total_size} bytes, types: {image_types})"
+                )
+            else:
+                self.logger.info("No images found in .docx document")
+
+            return styled_html
+
+        except Exception as e:
+            self.logger.error(f"Error in convert_docx_to_html_with_images: {e}")
+            raise
+
+    def convert_office_to_pdf(self, data: bytes, ext: str) -> bytes | None:
+        """Convert .doc/.docx bytes to PDF bytes."""
+        src_path = None
+        out_dir = None
+        pdf_path = None
+        try:
+            with tempfile.NamedTemporaryFile(suffix=ext, delete=False) as src:
+                src.write(data)
+                src.flush()
+                src_path = src.name
+            out_dir = tempfile.mkdtemp()
+            cmd = [
+                'libreoffice',
+                '--headless',
+                '--convert-to',
+                'pdf',
+                src_path,
+                '--outdir',
+                out_dir,
+            ]
+            subprocess.run(cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            pdf_path = os.path.join(out_dir, os.path.splitext(os.path.basename(src_path))[0] + '.pdf')
+            with open(pdf_path, 'rb') as f:
+                return f.read()
+        except Exception as e:
+            self.logger.warning(f"DOC/DOCX conversion failed: {e}")
+            try:
+                html_content = None
+                lower_ext = ext.lower()
+
+                try:
+                    html_content = self.convert_doc_with_pypandoc_and_images(data, ext)
+                    if html_content:
+                        self.logger.info("pypandoc conversion successful with potential image extraction")
+                except Exception as pe:
+                    self.logger.warning(f"pypandoc conversion failed: {pe}")
+
+                if not html_content and lower_ext == '.docx':
+                    try:
+                        import mammoth  # type: ignore
+                        html_content = self.convert_docx_to_html_with_images(data)
+                        self.logger.info("mammoth conversion successful with image extraction")
+                    except Exception as me:
+                        self.logger.warning(f"mammoth conversion failed: {me}")
+
+                if not html_content and lower_ext == '.doc':
+                    try:
+                        with tempfile.NamedTemporaryFile(suffix=ext, delete=False) as tmp:
+                            tmp.write(data)
+                            tmp.flush()
+                            tmp_path = tmp.name
+                        try:
+                            result = subprocess.run(
+                                ['antiword', tmp_path],
+                                check=True,
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE,
+                            )
+                            text = result.stdout.decode('utf-8', 'replace')
+                            html_content = f"<pre>{html.escape(text)}</pre>"
+                        finally:
+                            try:
+                                os.remove(tmp_path)
+                            except Exception:
+                                pass
+                    except Exception as te:
+                        self.logger.warning(f"antiword conversion failed: {te}")
+
+                if html_content and self.html_to_pdf:
+                    tmp_pdf_fd, tmp_pdf_path = tempfile.mkstemp(suffix='.pdf')
+                    os.close(tmp_pdf_fd)
+                    try:
+                        self.html_to_pdf(html_content, tmp_pdf_path)
+                        with open(tmp_pdf_path, 'rb') as f:
+                            return f.read()
+                    finally:
+                        try:
+                            os.remove(tmp_pdf_path)
+                        except Exception:
+                            pass
+            except Exception as fe:
+                self.logger.warning(f"Fallback DOC/DOCX conversion failed: {fe}")
+            return None
+        finally:
+            for p in (src_path, pdf_path):
+                if p and os.path.exists(p):
+                    try:
+                        os.remove(p)
+                    except Exception:
+                        pass
+            if out_dir:
+                try:
+                    shutil.rmtree(out_dir)
+                except Exception:
+                    pass
+
+    def eml_bytes_to_pdf_bytes(self, eml_bytes: bytes) -> bytes | None:
+        """Convert EML bytes to PDF bytes using convert_eml_to_pdf helper."""
+        try:
+            with tempfile.NamedTemporaryFile(suffix='.pdf', delete=False) as tmp_pdf:
+                pdf_path = tmp_pdf.name
+            ok = False
+            if self.eml_to_pdf:
+                ok = self.eml_to_pdf(eml_bytes, pdf_path)
+            if ok and os.path.exists(pdf_path):
+                with open(pdf_path, 'rb') as f:
+                    return f.read()
+            return None
+        except Exception as e:
+            self.logger.warning(f"EML to PDF conversion failed: {e}")
+            return None
+        finally:
+            try:
+                if 'pdf_path' in locals() and os.path.exists(pdf_path):
+                    os.remove(pdf_path)
+            except Exception:
+                pass
+

--- a/backend/multipart_parser.py
+++ b/backend/multipart_parser.py
@@ -1,0 +1,168 @@
+import re
+import uuid
+from typing import Any, Dict
+from logging import Logger
+
+
+class MultipartParser:
+    """Decode multipart/form-data payloads with graceful fallbacks."""
+
+    def __init__(self, logger: Logger):
+        self.logger = logger
+
+    def parse(self, body: bytes, content_type: str) -> Dict[str, Any]:
+        boundary = self._extract_boundary(content_type or "", body or b"")
+        if boundary:
+            self.logger.info("Multipart: using manual parser with extracted boundary")
+            return self.parse_manual(body, boundary)
+
+        try:
+            try:
+                from multipart import MultipartParser as MP, parse_options_header
+            except ImportError:
+                try:
+                    from multipart import MultipartParser as MP, parse_options_header
+                except ImportError:
+                    import multipart
+                    MP = multipart.MultipartParser
+                    parse_options_header = multipart.parse_options_header
+
+            ctype, params = parse_options_header(content_type or "")
+            boundary = params.get("boundary")
+            if ctype != "multipart/form-data" or not boundary:
+                self.logger.warning("No boundary in Content-Type; using single-file fallback")
+                return self.parse_single_file_fallback(body, content_type)
+
+            parser = MP(body, boundary)
+            files: Dict[str, Any] = {}
+            for part in parser.parts():
+                disp = part.headers.get(b"Content-Disposition", b"").decode("utf-8", "replace")
+                _, opts = parse_options_header(disp)
+                name = (opts.get("name") or "").strip('"')
+                filename = opts.get("filename")
+                if filename:
+                    files[name or "file"] = {
+                        "filename": filename.strip('"'),
+                        "content": part.raw,
+                        "content_type": part.headers.get(b"Content-Type", b"application/octet-stream").decode("utf-8", "replace"),
+                    }
+                else:
+                    files[name] = part.text
+            return files
+        except Exception as e:
+            self.logger.warning(f"multipart parser failed: {e}")
+            if "boundary=" in (content_type or ""):
+                try:
+                    boundary = content_type.split("boundary=", 1)[1].split(";", 1)[0].strip()
+                    return self.parse_manual(body, boundary)
+                except Exception as e2:
+                    self.logger.error(f"Manual parsing also failed: {e2}")
+            return self.parse_single_file_fallback(body, content_type)
+
+    def parse_manual(self, body: bytes, boundary: str) -> Dict[str, Any]:
+        boundary_bytes = f"--{boundary}".encode("utf-8")
+        parts = body.split(boundary_bytes)
+
+        files: Dict[str, Any] = {}
+        for part in parts[1:-1]:
+            if not part.strip():
+                continue
+
+            if b"\r\n\r\n" in part:
+                headers_section, content = part.split(b"\r\n\r\n", 1)
+            elif b"\n\n" in part:
+                headers_section, content = part.split(b"\n\n", 1)
+            else:
+                continue
+
+            content = content.rstrip(b"\r\n--")
+
+            headers = {}
+            for line in headers_section.decode("utf-8", errors="replace").split("\n"):
+                if ":" in line:
+                    key, value = line.split(":", 1)
+                    headers[key.strip().lower()] = value.strip()
+
+            content_disposition = headers.get("content-disposition", "")
+            if "name=" in content_disposition:
+                name = content_disposition.split("name=", 1)[1].split(";", 1)[0].strip('"')
+                if "filename=" in content_disposition:
+                    filename = content_disposition.split("filename=", 1)[1].split(";", 1)[0].strip('"')
+                    files[name] = {
+                        "filename": filename,
+                        "content": content,
+                        "content_type": headers.get("content-type", "application/octet-stream"),
+                    }
+                else:
+                    files[name] = content.decode("utf-8", errors="replace")
+
+        try:
+            best_key = None
+            for k, v in files.items():
+                if isinstance(v, dict) and 'content' in v:
+                    ct = str(v.get('content_type', '')).lower()
+                    fn = str(v.get('filename', ''))
+                    if ct == 'message/rfc822' or fn.lower().endswith('.eml'):
+                        best_key = k
+                        break
+            if best_key and 'file' not in files:
+                files['file'] = files[best_key]
+        except Exception as e:
+            self.logger.warning(f"Failed to select best multipart file part: {e}")
+
+        return files
+
+    def parse_single_file_fallback(self, body: bytes, content_type: str) -> Dict[str, Any]:
+        self.logger.info("Using single file fallback parser")
+        try:
+            if (body or b"").lstrip().startswith(b"--") or b"WebKitFormBoundary" in (body or b""):
+                boundary = self._extract_boundary(content_type or "", body or b"")
+                if boundary:
+                    self.logger.info("Fallback: detected multipart body, attempting manual parse via sniffed boundary")
+                    files = self.parse_manual(body, boundary)
+                    if isinstance(files, dict) and isinstance(files.get("file"), dict):
+                        return files
+        except Exception as e:
+            self.logger.warning(f"Fallback multipart sniff failed: {e}")
+
+        filename = "uploaded_file.eml"
+        try:
+            body_str = body.decode('utf-8', errors='replace')
+            if any(h in body_str[:1000] for h in ['From:', 'To:', 'Subject:', 'Date:']):
+                filename = f"upload_{uuid.uuid4().hex[:8]}.eml"
+        except Exception:
+            pass
+
+        return {
+            "file": {
+                "filename": filename,
+                "content": body,
+                "content_type": content_type if "eml" in (content_type or "") else "message/rfc822",
+            }
+        }
+
+    def _extract_boundary(self, content_type: str, body: bytes) -> str | None:
+        try:
+            m = re.search(r'boundary=(?:"?)([^;"\s]+)', content_type or "", re.IGNORECASE)
+            if m:
+                b = m.group(1).strip()
+                if b:
+                    return b
+
+            sample = (body or b"")[:4096]
+            if sample.startswith(b"--"):
+                line_end = sample.find(b"\r\n")
+                if line_end == -1:
+                    line_end = sample.find(b"\n")
+                if line_end != -1 and line_end > 2:
+                    token = sample[2:line_end].decode("utf-8", "ignore").strip()
+                    if token:
+                        return token
+
+            m2 = re.search(rb'----WebKitFormBoundary[0-9A-Za-z]+', sample)
+            if m2:
+                token = m2.group(0).decode("utf-8", "ignore")
+                return token.lstrip("-")
+        except Exception:
+            pass
+        return None

--- a/backend/request_parser.py
+++ b/backend/request_parser.py
@@ -1,0 +1,34 @@
+import base64
+import json
+from typing import Any, Dict
+
+
+class RequestParser:
+    """Utility for working with API Gateway events."""
+
+    def __init__(self, event: Dict[str, Any]):
+        self.event = event or {}
+        self.headers = self._lower_headers(self.event.get("headers", {}))
+        self.body = self._get_body_bytes(self.event)
+
+    @staticmethod
+    def _lower_headers(headers: Dict[str, Any]) -> Dict[str, str]:
+        return {str(k).lower(): v for k, v in (headers or {}).items()}
+
+    @staticmethod
+    def _get_body_bytes(event: Dict[str, Any]) -> bytes:
+        body = event.get("body", b"")
+        if event.get("isBase64Encoded"):
+            if isinstance(body, str):
+                return base64.b64decode(body)
+            return base64.b64decode(body or b"")
+        if isinstance(body, str):
+            return body.encode("utf-8", errors="ignore")
+        return body or b""
+
+    def json(self) -> Dict[str, Any]:
+        """Return parsed JSON body if present."""
+        try:
+            return json.loads((self.body or b"").decode("utf-8", "ignore") or "{}")
+        except Exception:
+            return {}

--- a/backend/router.py
+++ b/backend/router.py
@@ -1,0 +1,65 @@
+import os
+import json
+import logging
+from typing import Callable, Dict, Any, Tuple
+
+class LambdaRouter:
+    """Simple router for API Gateway events."""
+
+    def __init__(self, verify_browser: Callable[[], bool]):
+        self.verify_browser = verify_browser
+        self.logger = logging.getLogger(__name__)
+        self.cors_headers = {
+            'Access-Control-Allow-Origin': '*',
+            'Access-Control-Allow-Headers': 'Content-Type, X-App-Password, Authorization',
+            'Access-Control-Allow-Methods': 'OPTIONS, POST, GET'
+        }
+
+    def handle(self, event: Dict[str, Any], handlers: Dict[Tuple[str, str] | str, Callable[[Dict[str, Any]], Dict[str, Any]]]) -> Dict[str, Any]:
+        try:
+            import psutil
+            memory_info = psutil.virtual_memory()
+            self.logger.info(f"Available memory: {memory_info.available / 1024 / 1024:.1f} MB")
+            self.logger.info(f"PLAYWRIGHT_BROWSERS_PATH env var: {os.environ.get('PLAYWRIGHT_BROWSERS_PATH', 'Not set')}")
+
+            path = event.get('path', '') or ''
+            method = event.get('httpMethod', '') or ''
+
+            if path == '/api/convert' and method == 'POST':
+                if not self.verify_browser():
+                    self.logger.error("Playwright browser verification failed - using fallback PDF generation")
+
+            if method == 'OPTIONS':
+                return {'statusCode': 200, 'headers': self.cors_headers, 'body': ''}
+
+            self.logger.info(f"Processing request: {method} {path}")
+
+            if path.startswith('/api/download-all/') and method == 'GET':
+                response = handlers['download_all'](event)
+            elif path.startswith('/api/download/') and method == 'GET':
+                response = handlers['download'](event)
+            elif path.startswith('/api/twemoji/') and method == 'GET':
+                response = handlers['twemoji'](event)
+            else:
+                func = handlers.get((method, path))
+                if func:
+                    response = func(event)
+                else:
+                    response = {
+                        'statusCode': 404,
+                        'headers': {'Content-Type': 'application/json'},
+                        'body': json.dumps({'error': 'Not found'})
+                    }
+
+            if 'headers' not in response:
+                response['headers'] = {}
+            response['headers'].update(self.cors_headers)
+            return response
+
+        except Exception as e:
+            self.logger.error(f"Lambda handler error: {str(e)}")
+            return {
+                'statusCode': 500,
+                'headers': {'Content-Type': 'application/json', **self.cors_headers},
+                'body': json.dumps({'error': f'Internal server error: {str(e)}'})
+            }

--- a/debug_msg_attachments.py
+++ b/debug_msg_attachments.py
@@ -146,12 +146,9 @@ def test_backend_conversion(msg_path: str):
     
     try:
         # Import our backend functions
-        from lambda_function import (
-            extract_msg_attachments_with_embedded,
-            convert_msg_bytes_to_eml_bytes_with_attachments,
-            convert_msg_bytes_to_eml_bytes,
-            eml_bytes_to_pdf_bytes
-        )
+        from converter import EmailConverter
+        from lambda_function import eml_bytes_to_pdf_bytes
+        converter = EmailConverter()
         
         # Read the .msg file
         with open(msg_path, 'rb') as f:
@@ -162,7 +159,7 @@ def test_backend_conversion(msg_path: str):
         # Test 1: Basic .msg to EML conversion
         print("\n🔄 Test 1: Basic .msg to EML conversion...")
         try:
-            eml_bytes = convert_msg_bytes_to_eml_bytes(msg_bytes)
+            eml_bytes = converter.convert_msg_bytes_to_eml_bytes(msg_bytes)
             if eml_bytes:
                 print(f"✅ Successfully converted to EML ({len(eml_bytes)} bytes)")
             else:
@@ -174,7 +171,7 @@ def test_backend_conversion(msg_path: str):
         # Test 2: .msg to EML with attachment extraction
         print("\n🔄 Test 2: .msg to EML with attachment extraction...")
         try:
-            eml_bytes, attachments = convert_msg_bytes_to_eml_bytes_with_attachments(msg_bytes)
+            eml_bytes, attachments = converter.convert_msg_bytes_to_eml_bytes_with_attachments(msg_bytes)
             if eml_bytes:
                 print(f"✅ Successfully converted to EML ({len(eml_bytes)} bytes)")
                 print(f"📎 Extracted {len(attachments)} attachments:")
@@ -189,7 +186,7 @@ def test_backend_conversion(msg_path: str):
                     if att.get('content_type') == 'application/vnd.ms-outlook' or att.get('filename', '').lower().endswith('.msg'):
                         print(f"    🔄 Testing nested .msg to PDF conversion...")
                         try:
-                            nested_eml = convert_msg_bytes_to_eml_bytes(att.get('data', b''))
+                            nested_eml = converter.convert_msg_bytes_to_eml_bytes(att.get('data', b''))
                             if nested_eml:
                                 nested_pdf = eml_bytes_to_pdf_bytes(nested_eml)
                                 if nested_pdf:


### PR DESCRIPTION
## Summary
- add RequestParser and MultipartParser helpers for event and multipart handling
- delegate lambda handlers to these parsers to reduce inline logic
- document new parser utilities in backend README

## Testing
- `pytest` *(fails: SystemExit in old_tests/test_attachment_fix.py)*
- `pytest test_msg_debug.py`


------
https://chatgpt.com/codex/tasks/task_e_68c4a21b2d808322a41123ec4c0b76f5