### PR TITLE
feat: enable default s3 encryption

### DIFF
--- a/aws/template-container.yaml
+++ b/aws/template-container.yaml
@@ -41,6 +41,10 @@ Resources:
     Type: AWS::S3::Bucket
     Properties:
       BucketName: !Sub 'eml-converter-temp-${Environment}-${AWS::AccountId}'
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
       VersioningConfiguration:
         Status: Enabled
       LifecycleConfiguration:
@@ -64,6 +68,10 @@ Resources:
     Type: AWS::S3::Bucket
     Properties:
       BucketName: !Sub 'eml-converter-frontend-${Environment}-${AWS::AccountId}'
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
       WebsiteConfiguration:
         IndexDocument: index.html
         ErrorDocument: index.html

--- a/aws/template.yaml
+++ b/aws/template.yaml
@@ -40,6 +40,10 @@ Resources:
     Type: AWS::S3::Bucket
     Properties:
       BucketName: !Sub 'eml-converter-temp-${Environment}-${AWS::AccountId}'
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
       VersioningConfiguration:
         Status: Enabled
       LifecycleConfiguration:
@@ -63,6 +67,10 @@ Resources:
     Type: AWS::S3::Bucket
     Properties:
       BucketName: !Sub 'eml-converter-frontend-${Environment}-${AWS::AccountId}'
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
       WebsiteConfiguration:
         IndexDocument: index.html
         ErrorDocument: index.html


### PR DESCRIPTION
## Summary
- add AES256 default server-side encryption to TempFilesBucket and FrontendBucket in SAM templates

## Testing
- `pytest -q` *(fails: File not found)*
- `bash aws/test-deploy-params.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c5f593db9c8322a2e151f3591d997b