### PR TITLE
feat: add lifecycle rule for frontend bucket

### DIFF
--- a/aws/template-container.yaml
+++ b/aws/template-container.yaml
@@ -72,6 +72,11 @@ Resources:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
               SSEAlgorithm: AES256
+      LifecycleConfiguration:
+        Rules:
+          - Id: ExpireOldBuilds
+            Status: Enabled
+            ExpirationInDays: 30
       WebsiteConfiguration:
         IndexDocument: index.html
         ErrorDocument: index.html

--- a/aws/template.yaml
+++ b/aws/template.yaml
@@ -71,6 +71,11 @@ Resources:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
               SSEAlgorithm: AES256
+      LifecycleConfiguration:
+        Rules:
+          - Id: ExpireOldBuilds
+            Status: Enabled
+            ExpirationInDays: 30
       WebsiteConfiguration:
         IndexDocument: index.html
         ErrorDocument: index.html


### PR DESCRIPTION
## Summary
- auto-expire frontend bucket objects after 30 days via S3 lifecycle rule

## Testing
- `pytest` *(fails: File not found for test_msg_files/_External_ Starlight Solar comment letter.msg; SystemExit in old_tests/test_attachment_fix.py)*
- `cfn-lint aws/template.yaml aws/template-container.yaml` *(fails: Resource with id [EMLConverterFunction] is invalid. Runtime, Handler, Layers cannot be present when PackageType is of type `Image`)*
- `bash aws/deploy-container.sh --env dev` *(fails: Docker daemon is not running)*

------
https://chatgpt.com/codex/tasks/task_e_68c5f89fa90c83228b23ed7465e03160