### PR TITLE
Clean tmp storage and verify available space before PDF generation

### DIFF
--- a/DEPLOYMENT_GUIDE.md
+++ b/DEPLOYMENT_GUIDE.md
@@ -90,3 +90,15 @@ Check CloudWatch logs for:
 - "Successfully converted embedded text to PDF" - confirms conversion success
 
 If you don't see these messages, the deployment may not have taken effect.
+
+## 💾 Optional: Increase Lambda Ephemeral Storage
+
+For workflows that handle large attachments, consider allocating more than the default 512 MB of temporary storage:
+
+```bash
+aws lambda update-function-configuration \
+  --function-name YOUR_LAMBDA_FUNCTION_NAME \
+  --ephemeral-storage '{"Size": 1024}'
+```
+
+The example above provisions 1 GB of `/tmp` space for the function.


### PR DESCRIPTION
## Summary
- Clear `/tmp` at the start of `handle_convert_s3` to remove residual files
- Check available `/tmp` space before creating large PDFs and track temporary files for cleanup
- Add deployment note about increasing Lambda ephemeral storage for large attachments

## Testing
- `pytest` *(fails: INTERNALERROR SystemExit in old_tests/test_attachment_fix.py)*


------
https://chatgpt.com/codex/tasks/task_e_68c75bbe473c8322bb627b55d21895b7