### PR TITLE
Increase Lambda memory and ephemeral storage

### DIFF
--- a/aws/template-container.yaml
+++ b/aws/template-container.yaml
@@ -33,7 +33,9 @@ Conditions:
 Globals:
   Function:
     Timeout: 900  # 15 minutes for large files and PDF merging
-    MemorySize: 3008  # Maximum memory for PDF processing
+    MemorySize: 4096  # Increased memory for PDF processing
+    EphemeralStorage:
+      Size: 2048  # 2 GB temporary storage
 
 Resources:
   # S3 Bucket for temporary file storage and session management

--- a/aws/template.yaml
+++ b/aws/template.yaml
@@ -27,7 +27,9 @@ Conditions:
 Globals:
   Function:
     Timeout: 900  # 15 minutes for large files and PDF merging
-    MemorySize: 3008  # Maximum memory for PDF processing
+    MemorySize: 4096  # Increased memory for PDF processing
+    EphemeralStorage:
+      Size: 2048  # 2 GB temporary storage
     Runtime: python3.12
     Environment:
       Variables:


### PR DESCRIPTION
## Summary
- raise default Lambda memory allocation to 4096 MB
- allocate 2 GB of ephemeral `/tmp` storage for Lambda containers

## Testing
- `pytest` *(fails: File not found; SystemExit in old_tests/test_attachment_fix.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c7702dc6c083229a9e57e30b339f95