### PR TITLE
Add JWT auth with SQLAlchemy user model

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,22 @@
+import os
+from datetime import datetime
+from sqlalchemy import create_engine, Column, Integer, String, Boolean, DateTime
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+DATABASE_URL = os.environ.get('DATABASE_URL', 'sqlite:///users.db')
+engine = create_engine(DATABASE_URL, connect_args={'check_same_thread': False})
+SessionLocal = sessionmaker(bind=engine)
+Base = declarative_base()
+
+class User(Base):
+    __tablename__ = 'users'
+    id = Column(Integer, primary_key=True)
+    email = Column(String, unique=True, nullable=False)
+    password_hash = Column(String, nullable=False)
+    subscription_status = Column(String, default='free')
+    is_unlimited = Column(Boolean, default=False)
+    free_conversions_used = Column(Integer, default=0)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+def init_db():
+    Base.metadata.create_all(engine)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -15,3 +15,5 @@ tzlocal
 mammoth==1.6.0
 pypandoc-binary==1.13
 cryptography==41.0.7  # Pin to include ARC4 for legacy deps
+SQLAlchemy==1.4.49
+PyJWT==2.8.0

--- a/backend/router.py
+++ b/backend/router.py
@@ -11,7 +11,7 @@ class LambdaRouter:
         self.logger = logging.getLogger(__name__)
         self.cors_headers = {
             'Access-Control-Allow-Origin': '*',
-            'Access-Control-Allow-Headers': 'Content-Type, X-App-Password, Authorization',
+            'Access-Control-Allow-Headers': 'Content-Type, Authorization',
             'Access-Control-Allow-Methods': 'OPTIONS, POST, GET'
         }
 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -186,8 +186,7 @@ function App() {
         // Local development: use auth/check with headers
         console.log('🖥️ Using local development authentication');
         const headers = { 
-          'X-App-Password': passwordToAuthenticate, 
-          'Authorization': `Bearer ${passwordToAuthenticate}` 
+          'Authorization': `Bearer ${passwordToAuthenticate}`
         };
         
         try {
@@ -290,10 +289,10 @@ function App() {
       if (isCloudFrontUrl) {
         s3Url = `${API_BASE_URL}/api/convert-s3${password ? `?auth=${encodeURIComponent(password)}` : ''}`;
         if (password) {
-          s3Headers = { 'X-App-Password': password, 'Authorization': `Bearer ${password}` };
+          s3Headers = { 'Authorization': `Bearer ${password}` };
         }
       } else if (password) {
-        s3Headers = { 'X-App-Password': password, 'Authorization': `Bearer ${password}` };
+        s3Headers = { 'Authorization': `Bearer ${password}` };
       }
 
       const aggregated = [];
@@ -366,10 +365,10 @@ function App() {
       if (isCloudFrontUrl) {
         presignUrl = `${API_BASE_URL}/api/upload-url${pwd ? `?auth=${encodeURIComponent(pwd)}` : ''}`;
         if (pwd) {
-          presignHeaders = { 'X-App-Password': pwd, 'Authorization': `Bearer ${pwd}` };
+          presignHeaders = { 'Authorization': `Bearer ${pwd}` };
         }
       } else if (pwd) {
-        presignHeaders = { 'X-App-Password': pwd, 'Authorization': `Bearer ${pwd}` };
+        presignHeaders = { 'Authorization': `Bearer ${pwd}` };
       }
       const presign = await axios.post(presignUrl, {
         filename: f.name,

--- a/simple-frontend/index.html
+++ b/simple-frontend/index.html
@@ -479,7 +479,7 @@
             if (currentSessionId) {
                 const link = document.createElement('a');
                 const url = new URL(`${API_URL}/download-all/${currentSessionId}`);
-                if (currentPassword) url.searchParams.set('auth', currentPassword);
+                
                 link.href = url.toString();
                 link.download = `converted_pdfs_${currentSessionId}.zip`;
                 document.body.appendChild(link);
@@ -515,7 +515,7 @@
                 const response = await fetch(`${API_URL}/convert`, {
                     method: 'POST',
                     body: formData,
-                    headers: currentPassword ? { 'X-App-Password': currentPassword } : {}
+                    headers: currentPassword ? { 'Authorization': `Bearer ${currentPassword}` } : {}
                 });
 
                 if (!response.ok) {
@@ -574,7 +574,7 @@
         function downloadFile(sessionId, pdfFilename, downloadName) {
             const link = document.createElement('a');
             const url = new URL(`${API_URL}/download/${sessionId}/${pdfFilename}`);
-            if (currentPassword) url.searchParams.set('auth', currentPassword);
+            
             link.href = url.toString();
             link.download = downloadName;
             document.body.appendChild(link);
@@ -607,7 +607,7 @@
             try {
                 const res = await fetch(`${API_URL}/auth/check`, {
                     method: 'POST',
-                    headers: currentPassword ? { 'X-App-Password': currentPassword } : {}
+                    headers: currentPassword ? { 'Authorization': `Bearer ${currentPassword}` } : {}
                 });
                 if (res.ok) {
                     // Try to parse body for more detail


### PR DESCRIPTION
## Summary
- add SQLAlchemy `User` model with SQLite backing and seed an unlimited account
- implement JWT-based registration/login and auth decorator in Flask app
- remove X-App-Password usage from API, router, and frontends

## Testing
- `python -m py_compile backend/app.py backend/models.py backend/router.py`
- `pytest` *(fails: File not found: test_msg_files/_External_ Starlight Solar comment letter.msg)*

------
https://chatgpt.com/codex/tasks/task_e_68c7757467c483229c8830a530a6ba4a