### PR TITLE
Add SQLite user model and subscription DB initialization

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -48,6 +48,17 @@ if APP_PASSWORD:
 else:
     logger.info("Password protection: DISABLED (APP_PASSWORD not set)")
 
+# Subscription authentication mode
+AUTH_MODE = os.environ.get('AUTH_MODE', 'none')
+if AUTH_MODE == 'subscription':
+    try:
+        from .models import init_db, seed_unlimited_user
+    except ImportError:
+        from models import init_db, seed_unlimited_user
+    init_db()
+    seed_unlimited_user()
+    logger.info("Subscription mode enabled; database initialized")
+
 # Create a persistent storage directory for converted files
 STORAGE_DIR = os.path.join(os.getcwd(), 'converted_files')
 if not os.path.exists(STORAGE_DIR):

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,76 @@
+import os
+import sqlite3
+import secrets
+import hashlib
+import logging
+from datetime import datetime
+from dataclasses import dataclass
+from typing import Optional
+
+# Database configuration
+DB_PATH = os.environ.get('DATABASE_URL', 'msg_converter.db')
+
+
+def get_connection():
+    """Return a new SQLite connection."""
+    return sqlite3.connect(DB_PATH)
+
+
+def init_db():
+    """Create tables if they do not exist."""
+    with get_connection() as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS users (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                email TEXT UNIQUE NOT NULL,
+                password_hash TEXT NOT NULL,
+                subscription_status TEXT,
+                is_unlimited INTEGER DEFAULT 0,
+                free_conversions_used INTEGER DEFAULT 0,
+                created_at TEXT DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        conn.commit()
+
+
+@dataclass
+class User:
+    id: Optional[int]
+    email: str
+    password_hash: str
+    subscription_status: Optional[str] = None
+    is_unlimited: bool = False
+    free_conversions_used: int = 0
+    created_at: Optional[str] = None
+
+
+def seed_unlimited_user():
+    """Create a default unlimited user if none exists."""
+    email = "unlimited@example.com"
+    with get_connection() as conn:
+        cur = conn.cursor()
+        cur.execute("SELECT id FROM users WHERE email=?", (email,))
+        if cur.fetchone():
+            return
+        password = secrets.token_urlsafe(12)
+        password_hash = hashlib.sha256(password.encode()).hexdigest()
+        cur.execute(
+            """
+            INSERT INTO users (email, password_hash, subscription_status, is_unlimited, free_conversions_used, created_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                email,
+                password_hash,
+                "active",
+                1,
+                0,
+                datetime.utcnow().isoformat(),
+            ),
+        )
+        conn.commit()
+        logging.getLogger(__name__).info(
+            "Seeded unlimited user '%s' with password: %s", email, password
+        )


### PR DESCRIPTION
## Summary
- add SQLite-backed `User` model and helper functions
- initialize database and seed an unlimited user when `AUTH_MODE=subscription`

## Testing
- `pytest` *(fails: SystemExit in old_tests/test_attachment_fix.py)*
- `python - <<'PY'
import os
os.environ['AUTH_MODE'] = 'subscription'
from backend import app
import sqlite3
conn = sqlite3.connect('msg_converter.db')
print(conn.execute('SELECT email, is_unlimited FROM users').fetchall())
PY`


------
https://chatgpt.com/codex/tasks/task_e_68c77d4c8c0c832293f3a615028d2e08