### PR TITLE
Add JWT authentication for subscription mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,14 @@ If `APP_PASSWORD` is set in the environment:
 - The password is stored in browser localStorage for convenience
 - Downloads include the password as a query parameter automatically
 
+### Environment Variables
+
+| Variable | Description |
+| --- | --- |
+| `APP_PASSWORD` | Optional password gate for all endpoints. |
+| `AUTH_MODE` | Set to `subscription` to enable JWT-based registration and login. |
+| `SECRET_KEY` | Key used to sign JWTs when `AUTH_MODE=subscription`. |
+
 ## Project Structure
 
 ```

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -15,3 +15,4 @@ tzlocal
 mammoth==1.6.0
 pypandoc-binary==1.13
 cryptography==41.0.7  # Pin to include ARC4 for legacy deps
+PyJWT==2.8.0


### PR DESCRIPTION
## Summary
- support subscription mode with JWT-issued `/auth/register` and `/auth/login`
- secure conversion and download routes via `require_auth` decorator
- document environment variables and add PyJWT dependency

## Testing
- `pip install PyJWT`
- `pytest` *(fails: SystemExit in old_tests/test_attachment_fix.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c77e41030c8322afd89e18db56c0a9