### PR TITLE
Support subscription authentication mode

### DIFF
--- a/backend/router.py
+++ b/backend/router.py
@@ -9,9 +9,13 @@ class LambdaRouter:
     def __init__(self, verify_browser: Callable[[], bool]):
         self.verify_browser = verify_browser
         self.logger = logging.getLogger(__name__)
+        auth_mode = os.environ.get('AUTH_MODE', 'none')
+        allow_headers = 'Content-Type, Authorization'
+        if auth_mode != 'subscription':
+            allow_headers += ', X-App-Password'
         self.cors_headers = {
             'Access-Control-Allow-Origin': '*',
-            'Access-Control-Allow-Headers': 'Content-Type, X-App-Password, Authorization',
+            'Access-Control-Allow-Headers': allow_headers,
             'Access-Control-Allow-Methods': 'OPTIONS, POST, GET'
         }
 


### PR DESCRIPTION
## Summary
- Omit X-App-Password headers and password checks when `AUTH_MODE=subscription`
- Add build-time `REACT_APP_AUTH_MODE` to toggle between password and subscription UIs
- Store JWTs and send them via `Authorization` headers from the frontend

## Testing
- `pytest` *(fails: File not found: test_msg_files/_External_ Starlight Solar comment letter.msg)*
- `cd frontend && npm test -- --watchAll=false` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68c77fc838dc8322bc40063f2b84d766