### PR TITLE
Adjust email content width and preserve whitespace

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -633,7 +633,10 @@ class EMLToPDFConverter:
                         color: #666;
                     }}
                     .content {{
-                        max-width: 100%;
+                        max-width: 800px;
+                        width: 100%;
+                        margin: 0 auto;
+                        white-space: pre-wrap;
                         word-wrap: break-word;
                     }}
                     img {{


### PR DESCRIPTION
## Summary
- limit the rendered email body to a centered 800px column and preserve newline formatting with `white-space: pre-wrap`
- verified the base body styles remain aligned with the sample design

## Testing
- python - <<'PY'
import os
import tempfile
import json
from pathlib import Path
import sys
sys.path.insert(0, 'backend')
from app import EMLToPDFConverter

converter = EMLToPDFConverter()
msg_path = Path('test_msg_files/test-messege-How it looks as a message.msg')
with msg_path.open('rb') as f:
    msg_bytes = f.read()

eml_bytes, attachments = converter.msg_bytes_to_eml_bytes_with_attachments(msg_bytes)

tmp_eml = tempfile.NamedTemporaryFile(suffix='.eml', delete=False)
tmp_eml.write(eml_bytes)
tmp_eml.close()

output_dir = Path('converted_files/tests')
output_dir.mkdir(parents=True, exist_ok=True)
output_pdf = output_dir / 'test-messege-output.pdf'

try:
    subject = converter.convert_eml_to_pdf(tmp_eml.name, str(output_pdf), attachments)
    result = {
        'subject': subject,
        'pdf_exists': output_pdf.exists(),
        'pdf_size': output_pdf.stat().st_size if output_pdf.exists() else 0,
        'pdf_path': str(output_pdf.resolve())
    }
finally:
    os.unlink(tmp_eml.name)

print(json.dumps(result, indent=2))
PY

------
https://chatgpt.com/codex/tasks/task_e_68c8c4fbef708322b154e794404827e2