### PR TITLE
Adjust email header layout in PDF output

### DIFF
--- a/backend/lambda_function.py
+++ b/backend/lambda_function.py
@@ -1190,7 +1190,8 @@ def convert_eml_to_pdf(eml_content: bytes, output_path: str, twemoji_base_url: s
                 body {{
                     font-family: "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
                     line-height: 1.35;
-                    margin: 20px;
+                    margin: 0;
+                    padding: 0;
                     color: #333;
                     word-wrap: break-word;
                     /* --- FIX FOR WORD SPACING --- */
@@ -1231,13 +1232,13 @@ def convert_eml_to_pdf(eml_content: bytes, output_path: str, twemoji_base_url: s
                     font-family: "Noto Color Emoji", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
                 }}
                 .email-header {{
-                    margin-bottom: 20px;
+                    margin: 0 0 10px 0;
                     padding: 0;
-                    font-size: 13px;
+                    font-size: 11px;
                     line-height: 1.45;
                     color: #1f1f1f;
                 }}
-                .email-body {{ padding: 10px; }}
+                .email-body {{ padding: 0 10px 10px 0; }}
                 .header-item {{
                     display: flex;
                     align-items: baseline;


### PR DESCRIPTION
## Summary
- remove the extra body margin so email headers render at the top-left of the PDF content
- tighten the email header block styling with a smaller font size and compact spacing to match the expected layout

## Testing
- PYTHONPATH=backend python - <<'PY' ...


------
https://chatgpt.com/codex/tasks/task_e_68c8d7c0837483228703f17bf3210725