### PR TITLE
Ensure bold styling is retained in PDF output

### DIFF
--- a/backend/lambda_function.py
+++ b/backend/lambda_function.py
@@ -1221,6 +1221,7 @@ def convert_eml_to_pdf(eml_content: bytes, output_path: str, twemoji_base_url: s
                     word-spacing: normal !important;
                     text-align-last: left !important;
                 }}
+                .email-body b, .email-body strong {{ font-weight: 700; }}
                 [style*="text-align:justify"], [style*="text-align: justify"] {{
                   text-align: left !important;
                 }}


### PR DESCRIPTION
## Summary
- ensure email PDF styles explicitly set a heavier weight for <b>/<strong> content so emphasis survives rendering

## Testing
- PYTHONPATH=backend python - <<'PY' ... (generate bold_test.pdf)

------
https://chatgpt.com/codex/tasks/task_e_68c8d7a87a408322a45705c99ffd8cdf