### PR TITLE
Normalize email header addresses for HTML output

### DIFF
--- a/backend/tests/test_address_formatting.py
+++ b/backend/tests/test_address_formatting.py
@@ -1,0 +1,34 @@
+"""Tests for email address header formatting helpers."""
+
+from __future__ import annotations
+
+import html
+import sys
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+BACKEND_PATH = PROJECT_ROOT / "backend"
+if str(BACKEND_PATH) not in sys.path:
+    sys.path.insert(0, str(BACKEND_PATH))
+
+
+from lambda_function import _format_address_header  # noqa: E402  pylint: disable=wrong-import-position
+
+
+def test_multiple_recipients_preserve_angle_brackets() -> None:
+    """Addresses should retain angle brackets after formatting and escaping."""
+
+    header = '"Alpha, A." <alpha@example.com>, Beta <beta@example.com>'
+
+    formatted = _format_address_header(header)
+
+    assert (
+        formatted
+        == 'Alpha, A. <alpha@example.com>, Beta <beta@example.com>'
+    ), formatted
+
+    escaped = html.escape(formatted)
+
+    assert '&lt;alpha@example.com&gt;' in escaped
+    assert '&lt;beta@example.com&gt;' in escaped


### PR DESCRIPTION
## Summary
- parse decoded From/To headers into display/address pairs before HTML escaping
- ensure formatted addresses retain angle brackets and fall back gracefully when parsing fails
- add a focused test covering multi-recipient headers and escaped output

## Testing
- pytest backend/tests/test_address_formatting.py

------
https://chatgpt.com/codex/tasks/task_e_68c8d7bdeb6c8322b33297df5dca9ae0